### PR TITLE
[Feat/#5] Google Gemini API 연결 및 대화 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 src/main/resources/application-secret.yml
 src/main/resources/poppet-client.json
+src/main/resources/gemini-chat-prompt.txt

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-gcp-starter'
 	implementation 'com.google.cloud:google-cloud-texttospeech'
 
+	// web flux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -1,5 +1,10 @@
 package com.gdg.poppet.chat.application.service;
 
+import com.gdg.poppet.chat.domain.converter.ChatConverter;
+import com.gdg.poppet.chat.domain.model.Chat;
+import com.gdg.poppet.chat.domain.model.ChatRoom;
+import com.gdg.poppet.chat.domain.repository.ChatRepository;
+import com.gdg.poppet.chat.domain.repository.ChatRoomRepository;
 import com.gdg.poppet.chat.infra.gemini.application.service.GeminiService;
 import com.gdg.poppet.chat.infra.speech.application.GoogleCloudService;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +22,8 @@ public class ChatServiceImpl implements ChatService {
 
     private final GoogleCloudService googleCloudService;
     private final GeminiService geminiService;
+    private final ChatRepository chatRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     /**
      * 사용자의 음성 파일을 받아 맥락에 알맞게 이어질 대화 응답값을 생성 후 음성 파일로 변환해 반환한다.
@@ -26,20 +33,59 @@ public class ChatServiceImpl implements ChatService {
      */
     @Override
     public Resource chat(List<MultipartFile> requestFile) {
+        // TODO: TRANSACTION 분리
+
+        // 1. STT를 이용해 텍스트 추출
+        String requestText = speechToText(requestFile);
+        log.info("[*] requestText : {}", requestText);
+
+        // 2. Chatroom 생성
+        ChatRoom chatRoom = getChatRoom();
+
+        // 3. Chat 저장
+        Chat requestChat = ChatConverter.toChat(0, requestText, chatRoom);
+        chatRepository.save(requestChat);
+
+        // 4. Gemini를 이용해 응답 생성
+        String responseText = geminiService.generateAiResponse(requestText);
+        log.info("[*] responseText : {}", responseText);
+
+        // 5. Chat 저장
+        Chat responseChat = ChatConverter.toChat(1, responseText, chatRoom);
+        chatRepository.save(responseChat);
+
+        // 6. TTS를 이용해 음성파일 추출
+        return googleCloudService.textToSpeech(responseText);
+    }
+
+    private ChatRoom getChatRoom() {
+        // TODO: userId 수정
+        Long userId = 1L;
+
+        // TODO: finding chatRoom query
+        return chatRoomRepository.findByUserId(userId)
+                .orElseGet(() -> createNewChatRoom(userId));
+    }
+
+    private ChatRoom createNewChatRoom(Long userId) {
+        // 새로운 chatRoom 생성
+        ChatRoom newChatRoom = ChatConverter.toChatRoom(userId);
+        chatRoomRepository.save(newChatRoom);
+
+        // 이전 chatRoom 제거
+
+        // 가장 최근 chatroom summary 생성 (async)
+
+        return newChatRoom;
+    }
+
+    private String speechToText(List<MultipartFile> requestFile) {
         StringBuilder requestText = new StringBuilder();
 
         for (MultipartFile file : requestFile) {
-            // 1. STT를 이용해 텍스트 추출
             String text = googleCloudService.speechToText(file);
             requestText.append(text);
         }
-        log.info("[*] requestText : {}", requestText.toString());
-
-        // 2. Gemini를 이용해 응답 생성
-        String responseText = geminiService.generateAiResponse(requestText.toString());
-        log.info("[*] responseText : {}", responseText);
-
-        // 3. TTS를 이용해 음성파일 추출
-        return googleCloudService.textToSpeech(responseText);
+        return requestText.toString();
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -1,6 +1,7 @@
 package com.gdg.poppet.chat.application.service;
 
-import com.gdg.poppet.chat.infra.service.GoogleCloudService;
+import com.gdg.poppet.chat.infra.gemini.application.service.GeminiService;
+import com.gdg.poppet.chat.infra.speech.application.GoogleCloudService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
@@ -15,6 +16,7 @@ import java.util.List;
 public class ChatServiceImpl implements ChatService {
 
     private final GoogleCloudService googleCloudService;
+    private final GeminiService geminiService;
 
     /**
      * 사용자의 음성 파일을 받아 맥락에 알맞게 이어질 대화 응답값을 생성 후 음성 파일로 변환해 반환한다.
@@ -34,8 +36,10 @@ public class ChatServiceImpl implements ChatService {
         log.info("[*] requestText : {}", requestText.toString());
 
         // 2. Gemini를 이용해 응답 생성
+        String responseText = geminiService.generateAiResponse(requestText.toString());
+        log.info("[*] responseText : {}", responseText);
 
         // 3. TTS를 이용해 음성파일 추출
-        return googleCloudService.textToSpeech(requestText.toString());
+        return googleCloudService.textToSpeech(responseText);
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -1,6 +1,6 @@
 package com.gdg.poppet.chat.application.service;
 
-import com.gdg.poppet.chat.application.util.GoogleCloudUtil;
+import com.gdg.poppet.chat.infra.service.GoogleCloudService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
@@ -14,7 +14,7 @@ import java.util.List;
 @Slf4j
 public class ChatServiceImpl implements ChatService {
 
-    private final GoogleCloudUtil googleCloudUtil;
+    private final GoogleCloudService googleCloudService;
 
     /**
      * 사용자의 음성 파일을 받아 맥락에 알맞게 이어질 대화 응답값을 생성 후 음성 파일로 변환해 반환한다.
@@ -28,7 +28,7 @@ public class ChatServiceImpl implements ChatService {
 
         for (MultipartFile file : requestFile) {
             // 1. STT를 이용해 텍스트 추출
-            String text = googleCloudUtil.speechToText(file);
+            String text = googleCloudService.speechToText(file);
             requestText.append(text);
         }
         log.info("[*] requestText : {}", requestText.toString());
@@ -36,6 +36,6 @@ public class ChatServiceImpl implements ChatService {
         // 2. Gemini를 이용해 응답 생성
 
         // 3. TTS를 이용해 음성파일 추출
-        return googleCloudUtil.textToSpeech(requestText.toString());
+        return googleCloudService.textToSpeech(requestText.toString());
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
@@ -1,0 +1,20 @@
+package com.gdg.poppet.chat.domain.converter;
+
+import com.gdg.poppet.chat.domain.model.Chat;
+import com.gdg.poppet.chat.domain.model.ChatRoom;
+
+public class ChatConverter {
+    public static Chat toChat(int author, String content, ChatRoom chatRoom) {
+        return Chat.builder()
+                .author(author)
+                .content(content)
+                .chatRoom(chatRoom)
+                .build();
+    }
+
+    public static ChatRoom toChatRoom(Long userId) {
+        return ChatRoom.builder()
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/gdg/poppet/chat/domain/model/Chat.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/model/Chat.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "chat")
+@Table(name = "chats")
 public class Chat extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "chat_room")
+@Table(name = "chat_rooms")
 public class ChatRoom extends BaseEntity {
 
     @Id

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
@@ -2,8 +2,18 @@ package com.gdg.poppet.chat.domain.repository;
 
 import com.gdg.poppet.chat.domain.model.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    @Query("SELECT cr " +
+            "FROM ChatRoom cr " +
+            "WHERE cr.userId = :userId " +
+            "") // 1. user의 이메일 발송 기간(N일) 이전에 생성된
+    Optional<ChatRoom> findByUserId(@Param(value = "userId") Long userId);
 }

--- a/src/main/java/com/gdg/poppet/chat/infra/gemini/application/dto/GeminiRequestDto.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/gemini/application/dto/GeminiRequestDto.java
@@ -1,0 +1,35 @@
+package com.gdg.poppet.chat.infra.gemini.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GeminiRequestDto {
+
+    private List<Content> contents;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Content{
+        private List<Part> parts;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class Part{
+        private String text;
+    }
+}

--- a/src/main/java/com/gdg/poppet/chat/infra/gemini/application/dto/GeminiResponseDto.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/gemini/application/dto/GeminiResponseDto.java
@@ -1,0 +1,32 @@
+package com.gdg.poppet.chat.infra.gemini.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class GeminiResponseDto {
+
+    private List<Candidate> candidates;
+
+    @Data
+    public static class Candidate {
+        private Content content;
+        private String finishReason;
+    }
+
+    @Data
+    public static class Content {
+        private List<Parts> parts;
+        private String role;
+    }
+
+    @Data
+    public static class Parts {
+        private String text;
+    }
+}

--- a/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
@@ -1,0 +1,56 @@
+package com.gdg.poppet.chat.infra.gemini.application.service;
+
+import com.gdg.poppet.chat.infra.gemini.application.dto.GeminiRequestDto;
+import com.gdg.poppet.chat.infra.gemini.application.dto.GeminiResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GeminiService {
+
+    @Value("${ai.gemini.base-host}")
+    private String geminiBaseHost;
+
+    @Value("${ai.gemini.key}")
+    private String geminiApiKey;
+
+    private final WebClient webClient;
+
+    public String generateAiResponse(String request) {
+        GeminiRequestDto requestDto = GeminiRequestDto.builder()
+                .contents(List.of(new GeminiRequestDto.Content(
+                        List.of(new GeminiRequestDto.Part(request))
+                )))
+                .build();
+
+        GeminiResponseDto responseDto = webClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .scheme("https")
+                        .host(geminiBaseHost)
+                        .path("/v1beta/models/gemini-1.5-flash-latest:generateContent")
+                        .queryParam("key", geminiApiKey)
+                        .build())
+                .header("Accept", "application/json")
+                .bodyValue(requestDto)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), clientResponse -> {
+                    log.error("[*] GeminiService Request Failed - Status: {}, Body: {}",
+                            clientResponse.statusCode(),
+                            clientResponse.bodyToMono(String.class).block());
+                    return Mono.error(new RuntimeException("GeminiService Request Failed"));
+                })
+                .bodyToMono(GeminiResponseDto.class)
+                .block();
+
+        return responseDto.getCandidates().get(0).getContent().getParts().get(0).getText();
+    }
+
+}

--- a/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
@@ -2,6 +2,7 @@ package com.gdg.poppet.chat.infra.gemini.application.service;
 
 import com.gdg.poppet.chat.infra.gemini.application.dto.GeminiRequestDto;
 import com.gdg.poppet.chat.infra.gemini.application.dto.GeminiResponseDto;
+import com.gdg.poppet.global.util.ResourceLoader;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,10 +25,21 @@ public class GeminiService {
 
     private final WebClient webClient;
 
+    private static final String GEMINI_CHAT_PROMPT = ResourceLoader.getResourceContent("gemini-chat-prompt.txt");
+
+
+    /**
+     * 사용자의 요청 텍스트를 받아 지정된 프롬프트와 함께 Gemini API를 호출 후 응답을 반환한다.
+     * 프롬프팅을 통해 지정된 어투로 맥락에 알맞는 대화를 이어갈 응답을 반환하도록 지시한다.
+     * 호출 도중 예외가 발생할 경우 RuntimeException을 발생시킨다.
+     *
+     * @param request 사용자의 대화 요청 텍스트
+     * @return Gemini API의 응답값 중 TEXT Data
+     */
     public String generateAiResponse(String request) {
         GeminiRequestDto requestDto = GeminiRequestDto.builder()
                 .contents(List.of(new GeminiRequestDto.Content(
-                        List.of(new GeminiRequestDto.Part(request))
+                        List.of(new GeminiRequestDto.Part(GEMINI_CHAT_PROMPT + request))
                 )))
                 .build();
 

--- a/src/main/java/com/gdg/poppet/chat/infra/service/GoogleCloudService.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/service/GoogleCloudService.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.chat.application.util;
+package com.gdg.poppet.chat.infra.service;
 
 import com.gdg.poppet.global.exception.GlobalException;
 import com.gdg.poppet.global.status.ErrorStatus;
@@ -19,7 +19,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class GoogleCloudUtil {
+public class GoogleCloudService {
     private final SpeechClient speechClient;
     private final TextToSpeechClient textToSpeechClient;
 

--- a/src/main/java/com/gdg/poppet/chat/infra/speech/application/GoogleCloudService.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/speech/application/GoogleCloudService.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.chat.infra.service;
+package com.gdg.poppet.chat.infra.speech.application;
 
 import com.gdg.poppet.global.exception.GlobalException;
 import com.gdg.poppet.global.status.ErrorStatus;

--- a/src/main/java/com/gdg/poppet/chat/infra/speech/config/GoogleCloudConfig.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/speech/config/GoogleCloudConfig.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.chat.infra.config;
+package com.gdg.poppet.chat.infra.speech.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.speech.v1.SpeechClient;

--- a/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
+++ b/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
@@ -1,6 +1,7 @@
 package com.gdg.poppet.chat.presentation;
 
 import com.gdg.poppet.chat.application.service.ChatService;
+import com.gdg.poppet.chat.infra.gemini.application.service.GeminiService;
 import com.gdg.poppet.global.response.ApiResponse;
 import com.gdg.poppet.global.status.SuccessStatus;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +22,17 @@ import java.util.List;
 public class ChatController {
 
     private final ChatService chatService;
+    private final GeminiService geminiService;
 
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<Resource>> postChat( // TODO: NAMING
             @RequestParam("chat") List<MultipartFile> requestChat
     ){
         return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, chatService.chat(requestChat));
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<ApiResponse<String>> testChat(@RequestParam("chat") String chat) {
+        return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, geminiService.generateAiResponse(chat));
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
+++ b/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
@@ -31,7 +31,7 @@ public class ChatController {
         return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, chatService.chat(requestChat));
     }
 
-    @PostMapping("/test")
+    @PostMapping("/test") // 대화 기능 테스트를 위한 임시 API
     public ResponseEntity<ApiResponse<String>> testChat(@RequestParam("chat") String chat) {
         return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, geminiService.generateAiResponse(chat));
     }

--- a/src/main/java/com/gdg/poppet/global/config/WebClientConfig.java
+++ b/src/main/java/com/gdg/poppet/global/config/WebClientConfig.java
@@ -1,0 +1,15 @@
+package com.gdg.poppet.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+
+}

--- a/src/main/java/com/gdg/poppet/global/util/ResourceLoader.java
+++ b/src/main/java/com/gdg/poppet/global/util/ResourceLoader.java
@@ -1,0 +1,19 @@
+package com.gdg.poppet.global.util;
+
+import com.gdg.poppet.global.exception.GlobalException;
+import com.gdg.poppet.global.status.ErrorStatus;
+import org.springframework.core.io.ClassPathResource;
+
+import java.nio.charset.StandardCharsets;
+
+public class ResourceLoader {
+
+    public static String getResourceContent(String resourcePath) {
+        try {
+            var resource = new ClassPathResource(resourcePath);
+            return new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new GlobalException(ErrorStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/gdg/poppet/user/domain/model/Email.java
+++ b/src/main/java/com/gdg/poppet/user/domain/model/Email.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "user")
+@Table(name = "emails")
 public class Email extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "email_id", nullable = false)

--- a/src/main/java/com/gdg/poppet/user/domain/model/User.java
+++ b/src/main/java/com/gdg/poppet/user/domain/model/User.java
@@ -16,7 +16,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "user")
+@Table(name = "users")
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #5 

### 💡 작업내용
- Google Gemini API 연결했습니다.
  - gemini api secret key notion에 첨부했으니 확인 부탁드립니다.
  -  web flux 이용했습니다.
     - chat API 로직 자체는 동기적으로 진행되기 때문에  restTemplate 사용해도 무관하나, 추후 이메일 전송 / 대화 내용 요약 기능에 비동기 도입할 것을 고려해 해당 스택을 선택했습니다!
- gemini를 이용한 대화 기능 구현했습니다.
  - 프롬프팅 파일(txt) 추가했습니다. notion에 첨부된 파일 확인 부탁드립니다.    
- Entity table명 변경했습니다.
  - 테이블 충돌이 일어날 수 있으니 테스트하기 전 DB 먼저 초기화하시는 게 좋을 것 같습니다.
- 대화 기능 중 chatRoom 생성 로직 가이드 생성했습니다.
  - 로직 구현을 위해서는 userId가 필요하기 때문에 로그인 기능 구현 후 차차 수정하겠습니다.

### 📸 스크린샷

### 📝 기타
- util -> service 이름 변경했습니다.
