### PR TITLE
[Feat/ilwoo#3] .env로 key 관리, GoogleCloudConfig Json 문자열 형태로 변경

### DIFF
--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -48,15 +48,6 @@ jobs:
       - name: Show Jar files
         run: find . -name "*.jar"
 
-      ################################################################
-      # (유지) Secrets에서 GCP 인증 파일(poppet-client.json) 임시 생성
-      ################################################################
-      - name: Create poppet-client.json
-        run: echo "$POPPET_CLIENT_JSON" > poppet-client.json
-        env:
-          POPPET_CLIENT_JSON: ${{ secrets.POPPET_CLIENT_JSON }}
-      ################################################################
-
       # 5) Dockerfile 복호화 (Secrets에서 가져옴)
       - name: Decode Dockerfile from secret and save it
         run: |
@@ -93,7 +84,8 @@ jobs:
             DB_USERNAME=${{ secrets.DB_USERNAME }},
             DB_PASSWORD=${{ secrets.DB_PASSWORD }},
             AI_GEMINI_API_KEY=${{ secrets.AI_GEMINI_API_KEY }},
-            KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
+            KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }},
+            GCP_CREDENTIALS_JSON=${{ secrets.GCP_CREDENTIALS_JSON }}
 
       # 9) 배포 후 URL 출력
       - name: 'Show output'

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.env
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//.env
+	implementation 'io.github.cdimascio:java-dotenv:5.1.1'
 }
 
 dependencyManagement {

--- a/src/main/java/com/gdg/poppet/chat/infra/speech/config/GoogleCloudConfig.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/speech/config/GoogleCloudConfig.java
@@ -5,6 +5,8 @@ import com.google.cloud.speech.v1.SpeechClient;
 import com.google.cloud.speech.v1.SpeechSettings;
 import com.google.cloud.texttospeech.v1.TextToSpeechClient;
 import com.google.cloud.texttospeech.v1.TextToSpeechSettings;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -16,12 +18,14 @@ import java.io.IOException;
 @Slf4j
 @Configuration
 public class GoogleCloudConfig {
-    @Value("${spring.cloud.gcp.credentials.location}")
-    String gcsCredentials;
+    @Value("${GCP_CREDENTIALS_JSON}")
+    private String gcpCredentialsJson;
 
     @Bean
     public GoogleCredentials googleCredentials() throws IOException {
-        return GoogleCredentials.fromStream(new FileInputStream(gcsCredentials));
+        return GoogleCredentials.fromStream(
+                new ByteArrayInputStream(gcpCredentialsJson.getBytes(StandardCharsets.UTF_8))
+        );
     }
 
     @Bean

--- a/src/main/java/com/gdg/poppet/global/config/DotEnvConfig.java
+++ b/src/main/java/com/gdg/poppet/global/config/DotEnvConfig.java
@@ -1,0 +1,17 @@
+package com.gdg.poppet.global.config;
+
+import io.github.cdimascio.dotenv.Dotenv;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DotEnvConfig {
+
+    @Bean
+    public Dotenv dotenv() {
+        // .env 파일을 읽어서 환경변수로 사용
+        return Dotenv.configure().directory("./")
+                .ignoreIfMissing() // .env 파일이 없어도 에러 발생 안함
+                .load();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   profiles:
     active: dev
   datasource:
@@ -21,14 +23,12 @@ spring:
   cloud:
     gcp:
       credentials:
-        # GCP 인증 파일은 깃허브 Secrets에 파일 내용을 저장 후
-        # GitHub Actions에서 임시로 poppet-client.json 생성하여 사용
-        location: file:./poppet-client.json
+        location: ${GCP_CREDENTIALS_PATH}
 
 ai:
   gemini:
     base-host: generativelanguage.googleapis.com
-    key: ${AI_GEMINI_API_KEY}   # 민감 정보는 환경 변수로 주입
+    key: ${AI_GEMINI_API_KEY}
 
 kakao:
   auth:


### PR DESCRIPTION
### #️⃣ 관련 이슈
https://github.com/gdsc-ssu/poppet-api/issues/10
### 💡 작업내용
-  .env로 민감한 정보들을 관리하는 방식으로 전부 변경 변경했습니다.
- GoogleCloudConfig 인증하는 형태를 json문자열을 불러오는 형태로 변경했습니다.
- Notion에 .env내용 첨부했습니다

### 📸 스크린샷

### 📝 기타
