### PR TITLE
[Feat/#8] 음성 채팅방 구분 및 채팅 요약 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,6 @@ out/
 ### VS Code ###
 .vscode/
 
-src/main/resources/application-secret.yml
 src/main/resources/poppet-client.json
 src/main/resources/gemini-chat-prompt.txt
+src/main/resources/gemini-summary-prompt.txt

--- a/src/main/java/com/gdg/poppet/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/auth/application/AuthServiceImpl.java
@@ -8,7 +8,6 @@ import com.gdg.poppet.user.application.dto.response.UserDto;
 import com.gdg.poppet.user.domain.model.User;
 import com.gdg.poppet.user.domain.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/gdg/poppet/auth/domain/converter/AuthConverter.java
+++ b/src/main/java/com/gdg/poppet/auth/domain/converter/AuthConverter.java
@@ -1,5 +1,6 @@
 package com.gdg.poppet.auth.domain.converter;
 
+import com.gdg.poppet.user.domain.enums.EmailPeriod;
 import com.gdg.poppet.user.domain.enums.Gender;
 import com.gdg.poppet.user.domain.model.User;
 
@@ -10,6 +11,7 @@ public class AuthConverter {
                 .username(username)
                 .gender(Gender.fromString(gender))
                 .age(age)
+                .emailPeriod(EmailPeriod.THREE)
                 .build();
     }
 

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatService.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatService.java
@@ -8,5 +8,5 @@ import java.util.List;
 
 @Service
 public interface ChatService {
-    Resource chat(List<MultipartFile> message);
+    Resource chat(List<MultipartFile> message, String username);
 }

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -56,7 +56,7 @@ public class ChatServiceImpl implements ChatService {
         chatRepository.save(requestChat);
 
         // 4. Gemini를 이용해 응답 생성
-        String responseText = geminiService.generateAiResponse(requestText);
+        String responseText = geminiService.generateAiResponse(chatRoom.getSummary(), requestText);
         log.info("[*] responseText : {}", responseText);
 
         // 5. Chat 저장

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -77,7 +77,6 @@ public class ChatServiceImpl implements ChatService {
         return requestText.toString();
     }
 
-    @Transactional
     public ChatRoom getChatRoom(User user) {
         LocalDate emailPeriodDate = LocalDate.now().minusDays(user.getEmailPeriod().getValue());
 
@@ -88,7 +87,7 @@ public class ChatServiceImpl implements ChatService {
                 : chatRooms.get(0);
 
         // 설정된 이메일 전송 기간 내에 생성되었다면 채팅방 유지
-        if (!chatRoom.getCreatedAt().toLocalDate().isBefore(emailPeriodDate)) {
+        if (chatRoom.isValidChatRoom(emailPeriodDate)) {
             return chatRoom;
         }
 
@@ -107,14 +106,15 @@ public class ChatServiceImpl implements ChatService {
         chatRoomRepository.save(newChatRoom);
 
         // 이전 chatRoom 제거
-        deleteRecentChats(newChatRoom);
+        deleteRecentChats(chatRoom.getChatRoomId());
 
         return newChatRoom;
     }
 
-    public void deleteRecentChats(ChatRoom chatRoom) {
-        chatRepository.deleteChatsByChatRoom(chatRoom);
-        chatRoomRepository.delete(chatRoom);
+//    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteRecentChats(Long chatRoomId) {
+        chatRepository.deleteChatsByChatRoomId(chatRoomId);
+        chatRoomRepository.deleteChatRoomByChatRoomId(chatRoomId);
     }
 
     private String parseChatSummaryRequest(ChatRoom chatRoom) {

--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -7,12 +7,18 @@ import com.gdg.poppet.chat.domain.repository.ChatRepository;
 import com.gdg.poppet.chat.domain.repository.ChatRoomRepository;
 import com.gdg.poppet.chat.infra.gemini.application.service.GeminiService;
 import com.gdg.poppet.chat.infra.speech.application.GoogleCloudService;
+import com.gdg.poppet.global.exception.GlobalException;
+import com.gdg.poppet.global.status.ErrorStatus;
+import com.gdg.poppet.user.domain.model.User;
+import com.gdg.poppet.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -24,6 +30,7 @@ public class ChatServiceImpl implements ChatService {
     private final GeminiService geminiService;
     private final ChatRepository chatRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
 
     /**
      * 사용자의 음성 파일을 받아 맥락에 알맞게 이어질 대화 응답값을 생성 후 음성 파일로 변환해 반환한다.
@@ -32,7 +39,8 @@ public class ChatServiceImpl implements ChatService {
      * @return : AI의 대화 응답값을 음성 파일로 변환환 결과
      */
     @Override
-    public Resource chat(List<MultipartFile> requestFile) {
+    @Transactional
+    public Resource chat(List<MultipartFile> requestFile, String username) {
         // TODO: TRANSACTION 분리
 
         // 1. STT를 이용해 텍스트 추출
@@ -40,7 +48,8 @@ public class ChatServiceImpl implements ChatService {
         log.info("[*] requestText : {}", requestText);
 
         // 2. Chatroom 생성
-        ChatRoom chatRoom = getChatRoom();
+        User user = getUser(username);
+        ChatRoom chatRoom = getChatRoom(user);
 
         // 3. Chat 저장
         Chat requestChat = ChatConverter.toChat(0, requestText, chatRoom);
@@ -58,27 +67,6 @@ public class ChatServiceImpl implements ChatService {
         return googleCloudService.textToSpeech(responseText);
     }
 
-    private ChatRoom getChatRoom() {
-        // TODO: userId 수정
-        Long userId = 1L;
-
-        // TODO: finding chatRoom query
-        return chatRoomRepository.findByUserId(userId)
-                .orElseGet(() -> createNewChatRoom(userId));
-    }
-
-    private ChatRoom createNewChatRoom(Long userId) {
-        // 새로운 chatRoom 생성
-        ChatRoom newChatRoom = ChatConverter.toChatRoom(userId);
-        chatRoomRepository.save(newChatRoom);
-
-        // 이전 chatRoom 제거
-
-        // 가장 최근 chatroom summary 생성 (async)
-
-        return newChatRoom;
-    }
-
     private String speechToText(List<MultipartFile> requestFile) {
         StringBuilder requestText = new StringBuilder();
 
@@ -87,5 +75,62 @@ public class ChatServiceImpl implements ChatService {
             requestText.append(text);
         }
         return requestText.toString();
+    }
+
+    @Transactional
+    public ChatRoom getChatRoom(User user) {
+        LocalDate emailPeriodDate = LocalDate.now().minusDays(user.getEmailPeriod().getValue());
+
+        // 가장 최근 생성된 채팅방 조회
+        List<ChatRoom> chatRooms = chatRoomRepository.findByUsernameAndCreatedAt(user.getUsername());
+        ChatRoom chatRoom = chatRooms.isEmpty()
+                ? createFirstChatRoom(user.getUsername())
+                : chatRooms.get(0);
+
+        // 설정된 이메일 전송 기간 내에 생성되었다면 채팅방 유지
+        if (!chatRoom.getCreatedAt().toLocalDate().isBefore(emailPeriodDate)) {
+            return chatRoom;
+        }
+
+        // 기간을 초과했다면 새로운 채팅방 생성
+        return createNewChatRoom(user.getUsername(), chatRoom);
+    }
+
+    private ChatRoom createNewChatRoom(String username, ChatRoom chatRoom) {
+        // 가장 최근 chatroom summary 생성
+        String summaryRequest = parseChatSummaryRequest(chatRoom);
+        String summary = geminiService.generateChatSummary(summaryRequest);
+        log.info("[*] ChatRoomSummary : {}", summary);
+
+        // 새로운 chatRoom 생성
+        ChatRoom newChatRoom = ChatConverter.toChatRoom(username, summary);
+        chatRoomRepository.save(newChatRoom);
+
+        // 이전 chatRoom 제거
+        deleteRecentChats(newChatRoom);
+
+        return newChatRoom;
+    }
+
+    public void deleteRecentChats(ChatRoom chatRoom) {
+        chatRepository.deleteChatsByChatRoom(chatRoom);
+        chatRoomRepository.delete(chatRoom);
+    }
+
+    private String parseChatSummaryRequest(ChatRoom chatRoom) {
+        StringBuilder chatSummary = new StringBuilder();
+        chatRoom.getChats().forEach(
+                chat -> {chatSummary.append(chat.getContent());});
+        return chatSummary.toString();
+    }
+
+    private ChatRoom createFirstChatRoom(String username) {
+        ChatRoom newChatRoom = ChatConverter.toChatRoom(username, null);
+        return chatRoomRepository.save(newChatRoom);
+    }
+
+    private User getUser(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new GlobalException(ErrorStatus.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
@@ -12,9 +12,10 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatRoom toChatRoom(Long userId) {
+    public static ChatRoom toChatRoom(String username, String summary) {
         return ChatRoom.builder()
-                .userId(userId)
+                .username(username)
+                .summary(summary)
                 .build();
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
@@ -15,7 +15,7 @@ public class ChatConverter {
     public static ChatRoom toChatRoom(String username, String summary) {
         return ChatRoom.builder()
                 .username(username)
-                .summary(summary)
+                .summary(summary == null ? "" : summary)
                 .build();
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Entity
@@ -29,4 +30,8 @@ public class ChatRoom extends BaseEntity {
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Chat> chats;
+
+    public boolean isValidChatRoom(LocalDate emailPeriodDate) {
+        return !getCreatedAt().toLocalDate().isBefore(emailPeriodDate);
+    }
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
@@ -25,7 +25,7 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "summary", nullable = true, length = 1000)
     private String summary;
 
-    private Long userId;     // user 간접 참조
+    private String username;   // TODO: user 간접 참조
 
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Chat> chats;

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRepository.java
@@ -14,6 +14,6 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
     @Modifying
     @Query("DELETE " +
             "FROM Chat c " +
-            "WHERE c.chatRoom = :chatRoom")
-    void deleteChatsByChatRoom(@Value("chatRoom") ChatRoom chatRoom);
+            "WHERE c.chatRoom.chatRoomId = :chatRoomId")
+    void deleteChatsByChatRoomId(@Value("chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRepository.java
@@ -1,9 +1,19 @@
 package com.gdg.poppet.chat.domain.repository;
 
 import com.gdg.poppet.chat.domain.model.Chat;
+import com.gdg.poppet.chat.domain.model.ChatRoom;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRepository extends JpaRepository<Chat, Long> {
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM Chat c " +
+            "WHERE c.chatRoom = :chatRoom")
+    void deleteChatsByChatRoom(@Value("chatRoom") ChatRoom chatRoom);
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
@@ -6,14 +6,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
+
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    @Query("SELECT cr " +
+    @Query(value = "SELECT cr " +
             "FROM ChatRoom cr " +
-            "WHERE cr.userId = :userId " +
-            "") // 1. user의 이메일 발송 기간(N일) 이전에 생성된
-    Optional<ChatRoom> findByUserId(@Param(value = "userId") Long userId);
+            "WHERE cr.username = :username " +
+            "ORDER BY cr.createdAt DESC")
+    List<ChatRoom> findByUsernameAndCreatedAt(@Param(value = "username") String username);
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
@@ -2,6 +2,7 @@ package com.gdg.poppet.chat.domain.repository;
 
 import com.gdg.poppet.chat.domain.model.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,4 +18,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "WHERE cr.username = :username " +
             "ORDER BY cr.createdAt DESC")
     List<ChatRoom> findByUsernameAndCreatedAt(@Param(value = "username") String username);
+
+    @Modifying
+    @Query("DELETE " +
+            "FROM ChatRoom cr " +
+            "WHERE cr.chatRoomId = :chatRoomId")
+    void deleteChatRoomByChatRoomId(@Param(value = "chatRoomId") Long chatRoomId);
 }

--- a/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
@@ -24,19 +24,22 @@ public class GeminiService {
     @Value("${ai.gemini.key}")
     private String geminiApiKey;
 
-    @Value("${ai.gemini.location}")
-    private String geminiPromptLocaiton;
+    @Value("${ai.gemini.location.chat}")
+    private String geminiChatPromptLocation;
 
+    @Value("${ai.gemini.location.summary}")
+    private String geminiSummaryPromptLocation;
 
     private final WebClient webClient;
 
     private String geminiChatPrompt;
+    private String geminiSummaryPrompt;
 
     @PostConstruct
     void initPrompt() {
-        this.geminiChatPrompt = ResourceLoader.getResourceContent(geminiPromptLocaiton);
+        this.geminiChatPrompt = ResourceLoader.getResourceContent(geminiChatPromptLocation);
+        this.geminiSummaryPrompt = ResourceLoader.getResourceContent(geminiSummaryPromptLocation);
     }
-
 
     /**
      * 사용자의 요청 텍스트를 받아 지정된 프롬프트와 함께 Gemini API를 호출 후 응답을 반환한다. 프롬프팅을 통해 지정된 어투로 맥락에 알맞는 대화를 이어갈 응답을 반환하도록 지시한다. 호출 도중
@@ -46,12 +49,28 @@ public class GeminiService {
      * @return Gemini API의 응답값 중 TEXT Data
      */
     public String generateAiResponse(String request) {
-        GeminiRequestDto requestDto = GeminiRequestDto.builder()
-                .contents(List.of(new GeminiRequestDto.Content(
-                        List.of(new GeminiRequestDto.Part(geminiChatPrompt + request))
-                )))
-                .build();
+        GeminiRequestDto requestDto = getGeminiRequestDto(geminiChatPrompt, request);
+        return post(requestDto);
+    }
 
+    /**
+     *
+     * @param request 사용자의 채팅 내용을 합친 텍스트
+     * @return Gemini API의 응답값 중 TEXT Data
+     */
+    public String generateChatSummary(String request) {
+        GeminiRequestDto requestDto = getGeminiRequestDto(geminiSummaryPrompt, request);
+        return post(requestDto);
+    }
+
+    private GeminiRequestDto getGeminiRequestDto(String prompt, String request) {
+        return GeminiRequestDto.builder()
+                .contents(List.of(new GeminiRequestDto.Content(
+                        List.of(new GeminiRequestDto.Part(prompt + request))
+                ))).build();
+    }
+
+    public String post(GeminiRequestDto request) {
         GeminiResponseDto responseDto = webClient.post()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
@@ -60,10 +79,10 @@ public class GeminiService {
                         .queryParam("key", geminiApiKey)
                         .build())
                 .header("Accept", "application/json")
-                .bodyValue(requestDto)
+                .bodyValue(request)
                 .retrieve()
                 .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), clientResponse -> {
-                    log.error("[*] GeminiService Request Failed - Status: {}, Body: {}",
+                    log.error("[*] GeminiService AI Request Failed - Status: {}, Body: {}",
                             clientResponse.statusCode(),
                             clientResponse.bodyToMono(String.class).block());
                     return Mono.error(new RuntimeException("GeminiService Request Failed"));

--- a/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/gemini/application/service/GeminiService.java
@@ -48,7 +48,8 @@ public class GeminiService {
      * @param request 사용자의 대화 요청 텍스트
      * @return Gemini API의 응답값 중 TEXT Data
      */
-    public String generateAiResponse(String request) {
+    public String generateAiResponse(String summary, String request) {
+        request = "Summary="+summary+"/request="+request;
         GeminiRequestDto requestDto = getGeminiRequestDto(geminiChatPrompt, request);
         return post(requestDto);
     }

--- a/src/main/java/com/gdg/poppet/chat/infra/speech/config/GoogleCloudConfig.java
+++ b/src/main/java/com/gdg/poppet/chat/infra/speech/config/GoogleCloudConfig.java
@@ -5,8 +5,6 @@ import com.google.cloud.speech.v1.SpeechClient;
 import com.google.cloud.speech.v1.SpeechSettings;
 import com.google.cloud.texttospeech.v1.TextToSpeechClient;
 import com.google.cloud.texttospeech.v1.TextToSpeechSettings;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
+++ b/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
@@ -34,6 +34,6 @@ public class ChatController {
 
     @PostMapping("/test") // 대화 기능 테스트를 위한 임시 API
     public ResponseEntity<ApiResponse<String>> testChat(@RequestParam("chat") String chat) {
-        return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, geminiService.generateAiResponse(chat));
+        return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, geminiService.generateAiResponse("", chat));
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
+++ b/src/main/java/com/gdg/poppet/chat/presentation/ChatController.java
@@ -25,10 +25,11 @@ public class ChatController {
     private final GeminiService geminiService;
 
     @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<ApiResponse<Resource>> postChat( // TODO: NAMING
-            @RequestParam("chat") List<MultipartFile> requestChat
+    public ResponseEntity<ApiResponse<Resource>> postChat(
+            @RequestParam("chat") List<MultipartFile> requestChat,
+            @RequestParam("name") String name
     ){
-        return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, chatService.chat(requestChat));
+        return ApiResponse.success(SuccessStatus.CHAT_SUCCESS, chatService.chat(requestChat, name));
     }
 
     @PostMapping("/test") // 대화 기능 테스트를 위한 임시 API

--- a/src/main/java/com/gdg/poppet/global/status/ErrorStatus.java
+++ b/src/main/java/com/gdg/poppet/global/status/ErrorStatus.java
@@ -16,6 +16,9 @@ public enum ErrorStatus implements BaseErrorStatus {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 405, "허용되지 않은 메소드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다."),
 
+    // user
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, 404, "존재하지 않는 유저입니다."),
+
     // chat
     STT_FILE_IS_EMPTY(HttpStatus.BAD_REQUEST, 404, "음성 파일이 존재하지 않습니다.");
 

--- a/src/main/java/com/gdg/poppet/user/domain/enums/EmailPeriod.java
+++ b/src/main/java/com/gdg/poppet/user/domain/enums/EmailPeriod.java
@@ -1,0 +1,12 @@
+package com.gdg.poppet.user.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum EmailPeriod {
+    ONE(1), THREE(3), SEVEN(7);
+
+    private final int value;
+}

--- a/src/main/java/com/gdg/poppet/user/domain/model/User.java
+++ b/src/main/java/com/gdg/poppet/user/domain/model/User.java
@@ -2,6 +2,7 @@ package com.gdg.poppet.user.domain.model;
 
 
 import com.gdg.poppet.global.domain.BaseEntity;
+import com.gdg.poppet.user.domain.enums.EmailPeriod;
 import com.gdg.poppet.user.domain.enums.Gender;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -31,6 +32,9 @@ public class User extends BaseEntity {
 
     @Column(name = "age", nullable = false)
     private int age;
+
+    @Column(name = "email_period", nullable = false)
+    private EmailPeriod emailPeriod;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Email> emails;

--- a/src/main/java/com/gdg/poppet/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/gdg/poppet/user/domain/repository/UserRepository.java
@@ -14,4 +14,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "WHERE u.userId = :userId " +
             "")
     Optional<User> findByUserId(@Param(value = "userId") Long userId);
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  config:
+    import: optional:file:.env[.properties]
   profiles:
     active: dev
   datasource:
@@ -27,7 +29,9 @@ ai:
   gemini:
     base-host: generativelanguage.googleapis.com
     key: ${AI_GEMINI_API_KEY}
-    location: ${AI_GEMINI_PROMPT_LOCATION}
+    location:
+      chat: ${AI_GEMINI_CHAT_PROMPT_LOCATION}
+      summary: ${AI_GEMINI_SUMMARY_PROMPT_LOCATION}
 
 kakao:
   auth:


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #8 

### 💡 작업내용
- username으로 user 구분
  - 이전에 회의한 내용을 기반으로 spring security 적용 대신 username을 이용해 user를 식별합니다.
- user entity `email_period` field 추가  
  - 유저가 설정한 이메일 전송 주기를 저장하는 필드 추가했습니다.
  - `EmailPeriod` enum 생성했고, user 생성 시 3일을 기본값으로 설정했습니다. 
- 음성 채팅방 구분
  - 가장 최근 생성된 채팅방(c1)을 조회한 후, 현재로부터 유저가 설정한 email_period 기간 내에 생성되었다면 해당 채팅방을 사용합니다.
  - 그렇지 않다면 새로운 채팅방(c2)을 생성해 사용합니다.
    -  c1의 내용을 요약해 c2의 `summary` field에 저장하고 c1을 삭제합니다.
- 채팅 요약 기능
  - `chat-summary-prompt.txt` 파일을 추가해, cicd 및 env 파일 수정 필요합니다.

### 📸 스크린샷

### 📝 기타
- 한 패널 내에서 외부 API 호출 + Entity 저장 및 삭제 작업이 여러 개가 이루어져 트랜잭션 분리 기준을 어떻게 할지 고민입니다 ..
