### PR TITLE
[Feat/#15] 대화 내용 요약본 이메일 전송 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
 	//.env
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
+
+	// email
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 dependencyManagement {

--- a/src/main/java/com/gdg/poppet/auth/domain/converter/AuthConverter.java
+++ b/src/main/java/com/gdg/poppet/auth/domain/converter/AuthConverter.java
@@ -1,6 +1,6 @@
 package com.gdg.poppet.auth.domain.converter;
 
-import com.gdg.poppet.user.domain.enums.EmailPeriod;
+import com.gdg.poppet.email.domain.enums.EmailPeriod;
 import com.gdg.poppet.user.domain.enums.Gender;
 import com.gdg.poppet.user.domain.model.User;
 

--- a/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
@@ -28,10 +28,17 @@ public class ChatRoom extends BaseEntity {
 
     private String username;   // TODO: user 간접 참조
 
+    @Column(name = "is_mail_sent", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+    private boolean isMailSent;
+
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Chat> chats;
 
     public boolean isValidChatRoom(LocalDate emailPeriodDate) {
         return !getCreatedAt().toLocalDate().isBefore(emailPeriodDate);
+    }
+
+    public void updateIsMailSent() {
+        isMailSent = true;
     }
 }

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
@@ -24,4 +24,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             "FROM ChatRoom cr " +
             "WHERE cr.chatRoomId = :chatRoomId")
     void deleteChatRoomByChatRoomId(@Param(value = "chatRoomId") Long chatRoomId);
+
+    @Query(value = "SELECT cr " +
+            "FROM ChatRoom cr " +
+            "WHERE cr.username = :username " +
+            "AND cr.isMailSent = FALSE " +
+            "ORDER BY cr.createdAt DESC")
+    List<ChatRoom> findByUsernameAndCreatedAtAndIsMailSent(@Param(value = "username") String username);
 }

--- a/src/main/java/com/gdg/poppet/email/application/dto/request/EmailRequestDto.java
+++ b/src/main/java/com/gdg/poppet/email/application/dto/request/EmailRequestDto.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.user.application.dto.request;
+package com.gdg.poppet.email.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/src/main/java/com/gdg/poppet/email/application/dto/response/EmailDto.java
+++ b/src/main/java/com/gdg/poppet/email/application/dto/response/EmailDto.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.user.application.dto.response;
+package com.gdg.poppet.email.application.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
-public class EmailPeriodDto {
-    private int period;
+public class EmailDto {
+    private Long emailId;
+    private String emailAddress;
 }

--- a/src/main/java/com/gdg/poppet/email/application/dto/response/EmailPeriodDto.java
+++ b/src/main/java/com/gdg/poppet/email/application/dto/response/EmailPeriodDto.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.user.application.dto.response;
+package com.gdg.poppet.email.application.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 @AllArgsConstructor
-public class EmailDto {
-    private Long emailId;
-    private String emailAddress;
+public class EmailPeriodDto {
+    private int period;
 }

--- a/src/main/java/com/gdg/poppet/email/application/event/EmailSendEvent.java
+++ b/src/main/java/com/gdg/poppet/email/application/event/EmailSendEvent.java
@@ -1,0 +1,16 @@
+package com.gdg.poppet.email.application.event;
+
+import com.gdg.poppet.chat.domain.model.ChatRoom;
+import com.gdg.poppet.user.domain.model.User;
+import lombok.Getter;
+
+@Getter
+public class EmailSendEvent {
+    private final User user;
+    private final ChatRoom chatRoom;
+
+    public EmailSendEvent(User user, ChatRoom chatRoom) {
+        this.user = user;
+        this.chatRoom = chatRoom;
+    }
+}

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailService.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailService.java
@@ -16,4 +16,6 @@ public interface EmailService {
     List<EmailDto> postEmailAddress(String name, EmailRequestDto emailRequestDto);
     void patchEmailAddress(String name, Long emailId, EmailRequestDto emailRequestDto);
     void deleteEmailAddress(String name, Long emailId);
+
+    void sendEmail(String username);
 }

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailService.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailService.java
@@ -1,8 +1,8 @@
-package com.gdg.poppet.user.application.service;
+package com.gdg.poppet.email.application.service;
 
-import com.gdg.poppet.user.application.dto.request.EmailRequestDto;
-import com.gdg.poppet.user.application.dto.response.EmailDto;
-import com.gdg.poppet.user.application.dto.response.EmailPeriodDto;
+import com.gdg.poppet.email.application.dto.request.EmailRequestDto;
+import com.gdg.poppet.email.application.dto.response.EmailDto;
+import com.gdg.poppet.email.application.dto.response.EmailPeriodDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailService.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailService.java
@@ -12,8 +12,8 @@ public interface EmailService {
     EmailPeriodDto getEmailPeriod(String name);
     EmailPeriodDto patchEmailPeriod(String name, int period);
 
-    List<EmailDto> getEmailList(String name);
-    List<EmailDto> postEmail(String name, EmailRequestDto emailRequestDto);
-    void patchEmail(String name, Long emailId, EmailRequestDto emailRequestDto);
-    void deleteEmail(String name, Long emailId);
+    List<EmailDto> getEmailAddressList(String name);
+    List<EmailDto> postEmailAddress(String name, EmailRequestDto emailRequestDto);
+    void patchEmailAddress(String name, Long emailId, EmailRequestDto emailRequestDto);
+    void deleteEmailAddress(String name, Long emailId);
 }

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
@@ -58,7 +58,7 @@ public class EmailServiceImpl implements EmailService {
      * @return 사용자가 등록한 보호자 이메일 리스트
      */
     @Override
-    public List<EmailDto> getEmailList(String username) {
+    public List<EmailDto> getEmailAddressList(String username) {
         User user = getUser(username);
         List<Email> emailList = emailRepository.findByUser(user);
 
@@ -76,7 +76,7 @@ public class EmailServiceImpl implements EmailService {
      */
     @Transactional
     @Override
-    public List<EmailDto> postEmail(String username, EmailRequestDto emailRequestDto) {
+    public List<EmailDto> postEmailAddress(String username, EmailRequestDto emailRequestDto) {
         User user = getUser(username);
 
         validateDuplicateEmail(emailRequestDto.getNewEmail(), user);
@@ -103,7 +103,7 @@ public class EmailServiceImpl implements EmailService {
      */
     @Transactional
     @Override
-    public void patchEmail(String username, Long emailId, EmailRequestDto emailRequestDto) {
+    public void patchEmailAddress(String username, Long emailId, EmailRequestDto emailRequestDto) {
         User user = getUser(username);
         Email email = getEmail(emailId);
 
@@ -123,7 +123,7 @@ public class EmailServiceImpl implements EmailService {
      */
     @Transactional
     @Override
-    public void deleteEmail(String username, Long emailId) {
+    public void deleteEmailAddress(String username, Long emailId) {
         User user = getUser(username);
         Email email = getEmail(emailId);
         validateIsUserAuthorizedForEmail(user, email);

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
@@ -1,5 +1,9 @@
 package com.gdg.poppet.email.application.service;
 
+import com.gdg.poppet.chat.domain.model.ChatRoom;
+import com.gdg.poppet.chat.domain.repository.ChatRoomRepository;
+import com.gdg.poppet.email.application.event.EmailSendEvent;
+import com.gdg.poppet.email.infra.application.EmailSendService;
 import com.gdg.poppet.global.exception.GlobalException;
 import com.gdg.poppet.global.status.ErrorStatus;
 import com.gdg.poppet.email.application.dto.request.EmailRequestDto;
@@ -11,18 +15,24 @@ import com.gdg.poppet.user.domain.model.User;
 import com.gdg.poppet.email.domain.repository.EmailRepository;
 import com.gdg.poppet.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class EmailServiceImpl implements EmailService {
 
     private final UserRepository userRepository;
     private final EmailRepository emailRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final EmailSendService emailSendService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /**
      * 사용자의 이메일 전송 주기를 반환한다.
@@ -129,6 +139,31 @@ public class EmailServiceImpl implements EmailService {
         validateIsUserAuthorizedForEmail(user, email);
 
         emailRepository.delete(email);
+    }
+
+    /**
+     * 유저의 이메일 전송 주기에 따라, 주기 내에 생성된 이메일의 요약 내용을 이메일로 전송한다.
+     */
+    @Transactional
+    @Override
+    public void sendEmail(String username) {
+        // TODO: user data 얻는 과정 수정
+        User user = getUser(username);
+
+        // 가장 최근 생성되고 메일을 보내지 않은 채팅방 조회
+        List<ChatRoom> chatRooms = chatRoomRepository.findByUsernameAndCreatedAtAndIsMailSent(username);
+        if (chatRooms.isEmpty()) return;
+
+        // 메일 보낼 채팅방 요약 내용 추출
+        ChatRoom chatRoom = chatRooms.get(0);
+        String chatSummary = chatRoom.getSummary();
+        if (chatSummary == null) return;
+
+        // 메일 보냄 여부 수정
+        chatRoom.updateIsMailSent();
+
+        // 메일 전송 이벤트 발행
+        applicationEventPublisher.publishEvent(new EmailSendEvent(user, chatRoom));
     }
 
     private void validateIsUserAuthorizedForEmail(User user, Email email) {

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
@@ -1,14 +1,14 @@
-package com.gdg.poppet.user.application.service;
+package com.gdg.poppet.email.application.service;
 
 import com.gdg.poppet.global.exception.GlobalException;
 import com.gdg.poppet.global.status.ErrorStatus;
-import com.gdg.poppet.user.application.dto.request.EmailRequestDto;
-import com.gdg.poppet.user.application.dto.response.EmailDto;
-import com.gdg.poppet.user.application.dto.response.EmailPeriodDto;
-import com.gdg.poppet.user.domain.converter.EmailConverter;
-import com.gdg.poppet.user.domain.model.Email;
+import com.gdg.poppet.email.application.dto.request.EmailRequestDto;
+import com.gdg.poppet.email.application.dto.response.EmailDto;
+import com.gdg.poppet.email.application.dto.response.EmailPeriodDto;
+import com.gdg.poppet.email.domain.converter.EmailConverter;
+import com.gdg.poppet.email.domain.model.Email;
 import com.gdg.poppet.user.domain.model.User;
-import com.gdg.poppet.user.domain.repository.EmailRepository;
+import com.gdg.poppet.email.domain.repository.EmailRepository;
 import com.gdg.poppet.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/gdg/poppet/email/domain/converter/EmailConverter.java
+++ b/src/main/java/com/gdg/poppet/email/domain/converter/EmailConverter.java
@@ -1,8 +1,8 @@
-package com.gdg.poppet.user.domain.converter;
+package com.gdg.poppet.email.domain.converter;
 
-import com.gdg.poppet.user.application.dto.response.EmailDto;
-import com.gdg.poppet.user.application.dto.response.EmailPeriodDto;
-import com.gdg.poppet.user.domain.model.Email;
+import com.gdg.poppet.email.application.dto.response.EmailDto;
+import com.gdg.poppet.email.application.dto.response.EmailPeriodDto;
+import com.gdg.poppet.email.domain.model.Email;
 import com.gdg.poppet.user.domain.model.User;
 
 public class EmailConverter {

--- a/src/main/java/com/gdg/poppet/email/domain/enums/EmailPeriod.java
+++ b/src/main/java/com/gdg/poppet/email/domain/enums/EmailPeriod.java
@@ -1,4 +1,4 @@
-package com.gdg.poppet.user.domain.enums;
+package com.gdg.poppet.email.domain.enums;
 
 import com.gdg.poppet.global.exception.GlobalException;
 import com.gdg.poppet.global.status.ErrorStatus;

--- a/src/main/java/com/gdg/poppet/email/domain/model/Email.java
+++ b/src/main/java/com/gdg/poppet/email/domain/model/Email.java
@@ -1,6 +1,7 @@
-package com.gdg.poppet.user.domain.model;
+package com.gdg.poppet.email.domain.model;
 
 import com.gdg.poppet.global.domain.BaseEntity;
+import com.gdg.poppet.user.domain.model.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/gdg/poppet/email/domain/repository/EmailRepository.java
+++ b/src/main/java/com/gdg/poppet/email/domain/repository/EmailRepository.java
@@ -1,6 +1,6 @@
-package com.gdg.poppet.user.domain.repository;
+package com.gdg.poppet.email.domain.repository;
 
-import com.gdg.poppet.user.domain.model.Email;
+import com.gdg.poppet.email.domain.model.Email;
 import com.gdg.poppet.user.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/gdg/poppet/email/infra/application/EmailSendEventListener.java
+++ b/src/main/java/com/gdg/poppet/email/infra/application/EmailSendEventListener.java
@@ -1,0 +1,34 @@
+package com.gdg.poppet.email.infra.application;
+
+import com.gdg.poppet.email.application.event.EmailSendEvent;
+import com.gdg.poppet.email.domain.model.Email;
+import com.gdg.poppet.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailSendEventListener {
+
+    private final EmailSendService emailSendService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleEmailSendEvent(EmailSendEvent event) {
+        User user = event.getUser();
+        String summary = event.getChatRoom().getSummary();
+
+        for (Email email : user.getEmails()) {
+            try {
+                emailSendService.sendEmail(email.getEmailAddress(), summary);
+            } catch (Exception e) {
+                log.error("[*] {}으로 이메일 전송 중 오류 발생", email.getEmailAddress(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/gdg/poppet/email/infra/application/EmailSendService.java
+++ b/src/main/java/com/gdg/poppet/email/infra/application/EmailSendService.java
@@ -1,0 +1,30 @@
+package com.gdg.poppet.email.infra.application;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailSendService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendEmail(String to, String body) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+        String subject = "POPPET";
+
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
+        mimeMessageHelper.setTo(to);
+        mimeMessageHelper.setSubject(subject);
+        mimeMessageHelper.setText(body, true);
+
+        mailSender.send(mimeMessage);
+    }
+}

--- a/src/main/java/com/gdg/poppet/email/presentation/EmailController.java
+++ b/src/main/java/com/gdg/poppet/email/presentation/EmailController.java
@@ -38,7 +38,7 @@ public class EmailController {
     public ResponseEntity<ApiResponse<List<EmailDto>>> getEmailList(
             @RequestParam("name") String name
     ) {
-        return ApiResponse.success(SuccessStatus.GET_EMAIL_LIST_SUCCESS, emailService.getEmailList(name));
+        return ApiResponse.success(SuccessStatus.GET_EMAIL_LIST_SUCCESS, emailService.getEmailAddressList(name));
     }
 
     @PostMapping("")
@@ -46,7 +46,7 @@ public class EmailController {
             @RequestParam("name") String name,
             @RequestBody EmailRequestDto emailDto
     ) {
-        return ApiResponse.success(SuccessStatus.POST_EMAIL_SUCCESS, emailService.postEmail(name, emailDto));
+        return ApiResponse.success(SuccessStatus.POST_EMAIL_SUCCESS, emailService.postEmailAddress(name, emailDto));
     }
 
     @PatchMapping("/{emailId}")
@@ -55,7 +55,7 @@ public class EmailController {
             @PathVariable("emailId") Long emailId,
             @RequestBody EmailRequestDto emailDto
     ) {
-        emailService.patchEmail(name, emailId, emailDto);
+        emailService.patchEmailAddress(name, emailId, emailDto);
         return ApiResponse.success(SuccessStatus.PATCH_EMAIL_SUCCESS);
     }
 
@@ -64,7 +64,7 @@ public class EmailController {
             @RequestParam("name") String name,
             @PathVariable("emailId") Long emailId
     ) {
-        emailService.deleteEmail(name, emailId);
+        emailService.deleteEmailAddress(name, emailId);
         return ApiResponse.success(SuccessStatus.DELETE_EMAIL_SUCCESS);
     }
 }

--- a/src/main/java/com/gdg/poppet/email/presentation/EmailController.java
+++ b/src/main/java/com/gdg/poppet/email/presentation/EmailController.java
@@ -1,11 +1,11 @@
-package com.gdg.poppet.user.presentation;
+package com.gdg.poppet.email.presentation;
 
 import com.gdg.poppet.global.response.ApiResponse;
 import com.gdg.poppet.global.status.SuccessStatus;
-import com.gdg.poppet.user.application.dto.request.EmailRequestDto;
-import com.gdg.poppet.user.application.dto.response.EmailDto;
-import com.gdg.poppet.user.application.dto.response.EmailPeriodDto;
-import com.gdg.poppet.user.application.service.EmailService;
+import com.gdg.poppet.email.application.dto.request.EmailRequestDto;
+import com.gdg.poppet.email.application.dto.response.EmailDto;
+import com.gdg.poppet.email.application.dto.response.EmailPeriodDto;
+import com.gdg.poppet.email.application.service.EmailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/gdg/poppet/email/presentation/EmailController.java
+++ b/src/main/java/com/gdg/poppet/email/presentation/EmailController.java
@@ -67,4 +67,13 @@ public class EmailController {
         emailService.deleteEmailAddress(name, emailId);
         return ApiResponse.success(SuccessStatus.DELETE_EMAIL_SUCCESS);
     }
+
+    @GetMapping("/send")
+    public ResponseEntity<ApiResponse<EmailDto>> sendEmail(
+            @RequestParam("name") String name
+    ) {
+        emailService.sendEmail(name);
+        // TODO: 이메일 발송 후 response 수정
+        return ApiResponse.success(SuccessStatus.OK);
+    }
 }

--- a/src/main/java/com/gdg/poppet/global/config/AsyncConfig.java
+++ b/src/main/java/com/gdg/poppet/global/config/AsyncConfig.java
@@ -1,0 +1,10 @@
+package com.gdg.poppet.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+}

--- a/src/main/java/com/gdg/poppet/user/domain/model/User.java
+++ b/src/main/java/com/gdg/poppet/user/domain/model/User.java
@@ -1,8 +1,9 @@
 package com.gdg.poppet.user.domain.model;
 
 
+import com.gdg.poppet.email.domain.model.Email;
 import com.gdg.poppet.global.domain.BaseEntity;
-import com.gdg.poppet.user.domain.enums.EmailPeriod;
+import com.gdg.poppet.email.domain.enums.EmailPeriod;
 import com.gdg.poppet.user.domain.enums.Gender;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,20 @@ spring:
     gcp:
       credentials:
         location: ${GOOGLE_APPLICATION_CREDENTIALS}
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          ssl: false
+          starttls:
+            enable: true
+            required: true
 
 ai:
   gemini:


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #15 

### 💡 작업내용
- user - email domain 구분
- `ChatRoom` entity에 `is_mail_sent` 필드 추가
  - 해당 엔티티의 summary 내용을 이메일로 전송했는지 여부 판단 
- 사용자의 가장 최근 생성되었고 이메일을 전송하지 않은 채팅방 선택
  - ChatRoom을 만드는 로직에서 사용자가 선택한 이메일 전송 주기를 고려해 생성하므로, 보낼 채팅방을 선정하는 과정에서 이메일 전송 주기 필드는 고려하지 않았습니다 
- 메일을 보내야 하는 채팅방이 올바르게 선정되면, 해당 채팅방의 `is_mail_sent` 필드를 true로 변경 후 `EmailSendEvent` 발행
  - 필드 변경을 위해 transaction 내에서 해당 함수를 수행하는데, 외부 API(이메일 전송)을 transaction 내에서 수행할 시 발생할 문제를 고려하여, event 형식을 채택했습니다
- `@Asyn`, `@TransactionalEventListener` 을 이용해 비동기로 메일 전송 기능 구현
  - 앞서 언급한 DB 수정이 올바르게 반영된 후, 메일 전송  


### 📝 기타
- 스케쥴러 기능은 추후 구현할 예정입니다
- 이메일 템플릿 수정 후 PR 구분해서 올리겠습니다
