### PR TITLE
[Chore/#26] User-ChatRoom 간접참조 필드 수정 및 이메일 비동기 전송 제어 로직 수정

### DIFF
--- a/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/chat/application/service/ChatServiceImpl.java
@@ -81,9 +81,9 @@ public class ChatServiceImpl implements ChatService {
         LocalDate emailPeriodDate = LocalDate.now().minusDays(user.getEmailPeriod().getValue());
 
         // 가장 최근 생성된 채팅방 조회
-        List<ChatRoom> chatRooms = chatRoomRepository.findByUsernameAndCreatedAt(user.getUsername());
+        List<ChatRoom> chatRooms = chatRoomRepository.findByUserIdAndCreatedAt(user.getUserId());
         ChatRoom chatRoom = chatRooms.isEmpty()
-                ? createFirstChatRoom(user.getUsername())
+                ? createFirstChatRoom(user.getUserId())
                 : chatRooms.get(0);
 
         // 설정된 이메일 전송 기간 내에 생성되었다면 채팅방 유지
@@ -92,17 +92,17 @@ public class ChatServiceImpl implements ChatService {
         }
 
         // 기간을 초과했다면 새로운 채팅방 생성
-        return createNewChatRoom(user.getUsername(), chatRoom);
+        return createNewChatRoom(user.getUserId(), chatRoom);
     }
 
-    private ChatRoom createNewChatRoom(String username, ChatRoom chatRoom) {
+    private ChatRoom createNewChatRoom(String userId, ChatRoom chatRoom) {
         // 가장 최근 chatroom summary 생성
         String summaryRequest = parseChatSummaryRequest(chatRoom);
         String summary = geminiService.generateChatSummary(summaryRequest);
         log.info("[*] ChatRoomSummary : {}", summary);
 
         // 새로운 chatRoom 생성
-        ChatRoom newChatRoom = ChatConverter.toChatRoom(username, summary);
+        ChatRoom newChatRoom = ChatConverter.toChatRoom(userId, summary);
         chatRoomRepository.save(newChatRoom);
 
         // 이전 chatRoom 제거
@@ -124,8 +124,8 @@ public class ChatServiceImpl implements ChatService {
         return chatSummary.toString();
     }
 
-    private ChatRoom createFirstChatRoom(String username) {
-        ChatRoom newChatRoom = ChatConverter.toChatRoom(username, null);
+    private ChatRoom createFirstChatRoom(String userId) {
+        ChatRoom newChatRoom = ChatConverter.toChatRoom(userId, null);
         return chatRoomRepository.save(newChatRoom);
     }
 

--- a/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/converter/ChatConverter.java
@@ -12,9 +12,9 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatRoom toChatRoom(String username, String summary) {
+    public static ChatRoom toChatRoom(String userId, String summary) {
         return ChatRoom.builder()
-                .username(username)
+                .userId(userId)
                 .summary(summary == null ? "" : summary)
                 .build();
     }

--- a/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/model/ChatRoom.java
@@ -26,7 +26,7 @@ public class ChatRoom extends BaseEntity {
     @Column(name = "summary", nullable = true, length = 1000)
     private String summary;
 
-    private String username;   // TODO: user 간접 참조
+    private String userId;   // user 간접 참조
 
     @Column(name = "is_mail_sent", nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
     private boolean isMailSent;

--- a/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gdg/poppet/chat/domain/repository/ChatRoomRepository.java
@@ -15,9 +15,9 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query(value = "SELECT cr " +
             "FROM ChatRoom cr " +
-            "WHERE cr.username = :username " +
+            "WHERE cr.userId = :userId " +
             "ORDER BY cr.createdAt DESC")
-    List<ChatRoom> findByUsernameAndCreatedAt(@Param(value = "username") String username);
+    List<ChatRoom> findByUserIdAndCreatedAt(@Param(value = "userId") String userId);
 
     @Modifying
     @Query("DELETE " +
@@ -27,8 +27,8 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     @Query(value = "SELECT cr " +
             "FROM ChatRoom cr " +
-            "WHERE cr.username = :username " +
+            "WHERE cr.userId = :userId " +
             "AND cr.isMailSent = FALSE " +
             "ORDER BY cr.createdAt DESC")
-    List<ChatRoom> findByUsernameAndCreatedAtAndNotMailSent(@Param(value = "username") String username);
+    List<ChatRoom> findByUserIdAndCreatedAtAndNotMailSent(@Param(value = "userId") String userId);
 }

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
@@ -150,7 +150,7 @@ public class EmailServiceImpl implements EmailService {
         for (User user : userRepository.findAll()) {
 
             // 가장 최근 생성되고 메일을 보내지 않은 채팅방 조회
-            List<ChatRoom> chatRooms = chatRoomRepository.findByUsernameAndCreatedAtAndNotMailSent(user.getUsername());
+            List<ChatRoom> chatRooms = chatRoomRepository.findByUserIdAndCreatedAtAndNotMailSent(user.getUserId());
             if (chatRooms.isEmpty()) return;
 
             // 메일 보낼 채팅방 요약 내용 추출

--- a/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/email/application/service/EmailServiceImpl.java
@@ -147,16 +147,17 @@ public class EmailServiceImpl implements EmailService {
     @Transactional
     @Override
     public void sendEmail() {
+        // 이메일 주소를 등록한 전체 유저 리스트 조회
         for (User user : userRepository.findAll()) {
 
             // 가장 최근 생성되고 메일을 보내지 않은 채팅방 조회
             List<ChatRoom> chatRooms = chatRoomRepository.findByUserIdAndCreatedAtAndNotMailSent(user.getUserId());
-            if (chatRooms.isEmpty()) return;
+            if (chatRooms.isEmpty()) continue;
 
             // 메일 보낼 채팅방 요약 내용 추출
             ChatRoom chatRoom = chatRooms.get(0);
             String chatSummary = chatRoom.getSummary();
-            if (chatSummary == null) return;
+            if (chatSummary == null) continue;
 
             // 메일 보냄 여부 수정
             chatRoom.updateIsMailSent();

--- a/src/main/java/com/gdg/poppet/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/gdg/poppet/user/domain/repository/UserRepository.java
@@ -5,7 +5,6 @@ import com.gdg.poppet.user.domain.model.User;
 
 import java.util.List;
 import java.util.Optional;
-import org.aspectj.apache.bcel.classfile.Module.Provide;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,12 +22,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "WHERE u.userId = :userId " +
             "  AND u.provider = :provider")
     Optional<User> findByUserIdAndProvider(@Param("userId") String userId, @Param("provider") Provider provider);
-
-    @Query("SELECT u " +
-            "FROM User u " +
-            "JOIN FETCH u.emails el " +
-            "WHERE u.username = :username" )
-    Optional<User> findByUsername(String username);
 
     @Query("SELECT u " +
             "FROM User u " +


### PR DESCRIPTION
### #️⃣ 관련 이슈
- closed #26 

### 💡 작업내용
- `User` - `ChatRoom` entity간의 간접참조 필드 수정했습니다.
  - 기존 : security 적용 전 `username`을 기반으로 참조
  - 변경 : security 적용 후 `userId`를 기반으로 참조하도록 수정 
  - 해당 변경 사항에 따라, email, chat 도메인의 user 참조 관련 코드도 모두 수정해 수정사항 반영했습니다!  
- 비동기 이메일 전송 로직 제어문 수정
  - 기존 for문 내의 `return`문으로 인해 순서상 앞선 유저가 이미 이메일을 보냈다면, 그 다음 유저에게 이메일이 정상적으로 전송되지 않는다는 문제점을 발견했습니다.
  - 따라서, `return`을 `continue`로 변경했습니다. 


### 📝 기타
