### PR TITLE
[Feat/#30] 애플 로그인 name에러 수정

### DIFF
--- a/src/main/java/com/gdg/poppet/auth/application/dto/response/AppleProfileDTO.java
+++ b/src/main/java/com/gdg/poppet/auth/application/dto/response/AppleProfileDTO.java
@@ -44,6 +44,9 @@ public class AppleProfileDTO {
     @JsonProperty("nonce_supported")
     private Boolean nonceSupported;
 
+    @JsonProperty("name")
+    private String name; // 사용자 전체 이름 (firstName + lastName 조합)
+
     // 사용자 식별을 위한 ID 반환
     public String getId() {
         return this.sub;
@@ -52,5 +55,10 @@ public class AppleProfileDTO {
     // 이메일이 있을 때만 반환
     public String getValidEmail() {
         return (email != null && !email.trim().isEmpty()) ? email : null;
+    }
+
+    // 이름이 있을 때만 반환
+    public String getValidName() {
+        return (name != null && !name.trim().isEmpty()) ? name.trim() : null;
     }
 }

--- a/src/main/java/com/gdg/poppet/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/gdg/poppet/auth/application/service/AuthServiceImpl.java
@@ -150,13 +150,26 @@ public class AuthServiceImpl implements AuthService {
             Gender gender = Gender.MALE; // 기본값
             int defaultAge = 25; // 기본 나이
 
-            // Apple은 이메일이 있을 때만 사용자명으로 사용, 없으면 기본 이름
-            String username = appleProfile.getValidEmail();
+            // 우선순위: 1) 실제 이름, 2) 이메일 @ 앞 부분, 3) 기본 이름
+            String username = null;
+            
+            // 1. 실제 이름이 있는 경우 (첫 로그인 시에만 제공)
+            String fullName = appleProfile.getValidName();
+            if (fullName != null && !fullName.trim().isEmpty()) {
+                username = fullName.trim();
+            }
+            
+            // 2. 이름이 없고 이메일이 있는 경우
+            if (username == null) {
+                String email = appleProfile.getValidEmail();
+                if (email != null && !email.trim().isEmpty()) {
+                    username = email.split("@")[0];
+                }
+            }
+            
+            // 3. 둘 다 없는 경우 기본 이름
             if (username == null || username.trim().isEmpty()) {
-                username = "Apple사용자" + appleProfile.getId().substring(0, 8); // 기본 이름
-            } else {
-                // 이메일에서 @ 앞 부분을 사용자명으로 사용
-                username = username.split("@")[0];
+                username = "Apple사용자" + appleProfile.getId().substring(0, 8);
             }
 
             return userRepository.save(

--- a/src/main/java/com/gdg/poppet/auth/infra/util/AppleAuthClient.java
+++ b/src/main/java/com/gdg/poppet/auth/infra/util/AppleAuthClient.java
@@ -179,7 +179,41 @@ public class AppleAuthClient {
             .exp(claims.getExpiration().getTime())
             .authTime(claims.get("auth_time", Long.class))
             .nonceSupported(claims.get("nonce_supported", Boolean.class))
+            .name(parseFullNameFromClaims(claims))
             .build();
+    }
+
+    /**
+     * Claims에서 전체 이름 파싱 (firstName + lastName 조합)
+     */
+    private String parseFullNameFromClaims(Claims claims) {
+        try {
+            @SuppressWarnings("unchecked")
+            var nameMap = claims.get("name", java.util.Map.class);
+            
+            if (nameMap == null) {
+                return null;
+            }
+            
+            String firstName = (String) nameMap.get("firstName");
+            String lastName = (String) nameMap.get("lastName");
+            
+            StringBuilder fullName = new StringBuilder();
+            if (firstName != null && !firstName.trim().isEmpty()) {
+                fullName.append(firstName.trim());
+            }
+            if (lastName != null && !lastName.trim().isEmpty()) {
+                if (fullName.length() > 0) {
+                    fullName.append(" ");
+                }
+                fullName.append(lastName.trim());
+            }
+            
+            return fullName.length() > 0 ? fullName.toString() : null;
+        } catch (Exception e) {
+            log.warn("name claim 파싱 실패: {}", e.getMessage());
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
### #️⃣ 관련 이슈
#30 

### 💡 작업내용
  - Apple OAuth에서 name 스코프 지원 추가
  - AppleProfileDTO에 name 필드 추가하여 사용자 실제 이름 처리
  - AppleAuthClient에서 JWT claims의 firstName/lastName 파싱 로직 구현
  - AuthServiceImpl에서 Apple 사용자명 생성 우선순위 개선:
    a. 실제 이름 (첫 로그인 시 제공)
    b. 이메일 @ 앞 부분
    c. 기본 이름 ("Apple사용자" + ID 일부)
  - 복잡한 중첩 구조 대신 단순한 String 타입으로 name 필드 구현

### 📸 스크린샷

### 📝 기타
  - Apple OAuth의 name 정보는 첫 로그인 시에만 제공되므로 클라이언트에서 name 스코프 요청 필요
  - 기존 "mj7zpg9ry4" 같은 임의 문자열 대신 실제 사용자 이름 표시 가능
  - Apple은 성별/나이 정보를 제공하지 않으므로 별도 입력 폼 필요해보입니다.
